### PR TITLE
PCConfiguration: fix device name for depth camera

### DIFF
--- a/papart-examples/calibration/PCConfiguration/testView.pde
+++ b/papart-examples/calibration/PCConfiguration/testView.pde
@@ -77,7 +77,7 @@ class TestView extends PApplet {
         if(depthCameraConfig.getCameraType() == Camera.Type.FAKE){
             return;
         }
-        depthCameraConfig.setCameraName(cameraIdText.getText());
+        depthCameraConfig.setCameraName(depthCameraIdText.getText());
 
         camera = depthCameraConfig.createCamera();
         camera.setParent(this);


### PR DESCRIPTION
Incorrect parameters were passed down to depth cameras (stolen from RGB cameras actually).